### PR TITLE
Allow options to be passed in, default indented syntax for *.sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,17 @@
 const sass = require('node-sass')
+const extend = require('xtend')
 
 module.exports = sheetifySass
 
 // SASS plugin for Sheetify
 // (str, str, obj, fn) -> null
 function sheetifySass (filename, source, options, done) {
-  const sassOpts = {
+  const sassOpts = extend({
     data: source,
-    file: filename
-  }
+    file: filename,
+    indentedSyntax: /\.sass$/i.test(filename)
+  }, options)
+
   sass.render(sassOpts, function (err, res) {
     if (err) return done(err)
     done(null, String(res.css))

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-sass": "^3.4.2"
+    "node-sass": "^3.4.2",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "bl": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependency-check": "^2.5.1",
     "insert-css": "^0.2.0",
     "istanbul": "^0.4.2",
-    "sheetify": "^4.1.0",
+    "sheetify": "^5.0.0",
     "standard": "^6.0.7",
     "tape": "^4.5.0"
   }

--- a/test/expected.css
+++ b/test/expected.css
@@ -1,5 +1,8 @@
-._fa09a948 .baz {
+._30135bb0 .baz {
   color: purple; }
 
-._fa09a948 .foo .bar {
+._30135bb0 .qux {
+  color: yellow; }
+
+._30135bb0 .foo .bar {
   color: blue; }

--- a/test/indent-import.sass
+++ b/test/indent-import.sass
@@ -1,0 +1,2 @@
+.qux
+  color: yellow

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const bl = require('bl')
 const fs = require('fs')
 
 test('sheetify-sass', function (t) {
-  t.test('should transform sass', function (t) {
+  t.test('should transform sass and scss', function (t) {
     const expected = fs.readFileSync(path.join(__dirname, 'expected.css'))
 
     t.plan(2)

--- a/test/source.js
+++ b/test/source.js
@@ -2,6 +2,7 @@ const sf = require('sheetify')
 
 sf`
   @import './import.scss';
+  @import './indent-import.sass';
   .foo {
     .bar {
       color: blue;


### PR DESCRIPTION
I had to upgrade to sheetify 5 because even the current tests are failing on sheetify 4.x.
