### PR TITLE
Update dependencies and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-sass": "^3.4.2",
+    "node-sass": "^4.5.3",
     "xtend": "^4.0.1"
   },
   "devDependencies": {
     "bl": "^1.1.2",
-    "browserify": "^13.0.0",
+    "browserify": "^14.4.0",
     "css-extract": "^1.1.3",
     "dependency-check": "^2.5.1",
-    "insert-css": "^1.0.0",
+    "insert-css": "^2.0.0",
     "istanbul": "^0.4.2",
-    "sheetify": "^5.1.1",
-    "standard": "^8.0.0",
+    "sheetify": "^6.1.0",
+    "standard": "^10.0.2",
     "tape": "^4.5.0"
   }
 }

--- a/test/expected.css
+++ b/test/expected.css
@@ -1,8 +1,8 @@
-._30135bb0 .baz {
+._6d606626 .baz {
   color: purple; }
 
-._30135bb0 .qux {
+._6d606626 .qux {
   color: yellow; }
 
-._30135bb0 .foo .bar {
+._6d606626 .foo .bar {
   color: blue; }

--- a/test/import.scss
+++ b/test/import.scss
@@ -1,3 +1,3 @@
-.baz {
+:host .baz {
   color: purple;
 }

--- a/test/indent-import.sass
+++ b/test/indent-import.sass
@@ -1,2 +1,2 @@
-.qux
+\:host .qux
   color: yellow

--- a/test/source.js
+++ b/test/source.js
@@ -3,7 +3,7 @@ const sf = require('sheetify')
 sf`
   @import './import.scss';
   @import './indent-import.sass';
-  .foo {
+  :host .foo {
     .bar {
       color: blue;
     }


### PR DESCRIPTION
@yoshuawuyts sheetify-sass has some pretty old deps, I'm having issues w/`npm install` as a result. I also updated the tests to pass with latest sheetify and node-sass.

- Update deps and devdeps to latest
- Fix tests to use `:host` selector for postcss-prefix@2 
- Fix test/indent-import.sass to escape the `:host` for node-sass@4 (see sass/libsass#2245)
